### PR TITLE
QEMU information added

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,14 @@ Virtual machines are located in:
 
 Virtuaalikoneet$ -> VMware -> CompSec
 
+#### Running the Virtual machines under QEMU
+If you are using QEMU/KVM, you cannot directly load the .vmdk file to run the virtual machines as-is due to lack of support for split .vmdk files.
+
+In order to combine the .vmdk disk parts into a format QEMU can load you need to convert them into a .qcow2 disk file using qemu-img: 
+```shell
+qemu-img convert Kali.vmdk Kali.qcow2
+```
+
 ## Getting virtual machines remotely
 
 


### PR DESCRIPTION
Added information about running disk images under QEMU/KVM to main readme.md.
Solution sourced from [this askubuntu thread](https://askubuntu.com/questions/4398/how-do-i-convert-a-multiple-part-vmdk-disk-image-to-qcow2), but it should work on any Linux distro with QEMU installed